### PR TITLE
Align legend quick reference with TAS resource hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,35 +82,38 @@
       <header class="legend-header">
         <h2>Legend &amp; Quick Reference</h2>
         <p>
-          Every colour represents a different allocation state. Use this guide while dragging subjects
-          or pinning key sections so you always know what is ready, what needs review and what is locked
-          in for term planning.
+          Use this quick guide to understand how the TAS resource hub is organised. Each colour calls out a
+          different way to work with the live documents, so you can brief staff and update materials with
+          confidence.
         </p>
       </header>
       <div class="legend-grid" role="list">
         <article class="legend-card available" role="listitem">
-          <span class="legend-status">Available subject</span>
-          <p>Open sections with resources ready to deploy. Tap the star to secure them for quick access.</p>
+          <span class="legend-status">Faculty overviews</span>
+          <p>
+            Start with the category summaries to orient new staff. Each overview highlights the focus area,
+            live section count and any key onboarding notes.
+          </p>
         </article>
         <article class="legend-card allocated" role="listitem">
-          <span class="legend-status">Allocated subject</span>
+          <span class="legend-status">Live resource sets</span>
           <p>
-            Sections that already have detailed plans and linked assets. Review the links to brief
-            relieving teachers.
+            Sections that list Google Drive folders, programs or templates are ready to open. Check the
+            status tag to see when each bundle was last updated.
           </p>
         </article>
         <article class="legend-card pinned" role="listitem">
-          <span class="legend-status">Pinned spotlight</span>
+          <span class="legend-status">Pinned collections</span>
           <p>
-            Your personal shortlist. Toggle “Show pinned only” in the control hub when you need a rapid
-            briefing set.
+            Tap the star on any section to keep it in your morning briefing list. Use the pinned filter to
+            surface the resources you need in seconds.
           </p>
         </article>
         <article class="legend-card warning" role="listitem">
-          <span class="legend-status">Room clash</span>
+          <span class="legend-status">Needs a refresh</span>
           <p>
-            Check any sections marked with clashing resources or outdated files before signing off the
-            matrix.
+            If a section has no links or shows an older year, flag it for follow up. Update the linked
+            documents before sharing the hub with casual staff.
           </p>
         </article>
       </div>


### PR DESCRIPTION
## Summary
- rewrite the legend quick reference copy so it reflects how the TAS resource hub is structured
- clarify what each colour block represents, including summaries, live resources, pinned collections and follow-up items

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d5d6337f7483269571f4bd9940650a