### PR TITLE
Allow header to scroll away with page

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -34,8 +34,7 @@ body {
 }
 
 .app-header {
-  position: sticky;
-  top: 0;
+  position: static;
   z-index: 10;
   display: grid;
   gap: 1.75rem;


### PR DESCRIPTION
## Summary
- remove the sticky positioning on the top header so it scrolls off screen

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d5d5feb1408326ad15531b76367ebf