### PR TITLE
Deduplicate resource links and clarify cross references

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -21,19 +21,11 @@
         "code": "A2",
         "title": "Faculty Management Plan",
         "status": "updated 2025",
-        "description": "4-year Faculty Management Plan outlines the TAS faculties goals and direction for a 4 year period. It relates direc_tly to the school plan and the TAS staffs Personal Development plans. (PDP’s.) TAS draft administration plan can be found here. A slide show on how to make a great faculty can be found here.",
+        "description": "4-year Faculty Management Plan outlines the TAS faculty's goals and direction for a 4 year period. It relates directly to the school plan (see the School Plan section) and the TAS staff Personal Development plans (see Staff Professional Development - PDP’s and Teacher Professional Learning). TAS draft administration plan can be found here. A slide show on how to make a great faculty can be found here.",
         "links": [
           {
             "label": "4-year Faculty Management Plan",
             "url": "https://drive.google.com/open?id=1-6R5XZqtIiMPZhjNfpNGCByvtWgSOI7gP6RlOvQFuY8"
-          },
-          {
-            "label": "school plan",
-            "url": "https://drive.google.com/drive/folders/17ATo7vE9GAYLf4aBQo-3cT0NQ8gKL-0M?usp=sharing"
-          },
-          {
-            "label": "Personal Development plans. (PDP’s.)",
-            "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvb0JjS0lDalZRQTg"
           },
           {
             "label": "TAS draft administration plan",
@@ -99,10 +91,6 @@
             "url": "https://drive.google.com/open?id=1OyympKBcjFtQPNibjC9O3ZkLj48ssmCu"
           },
           {
-            "label": "headteacher roster includes times for Bus Duty, Minute Taking, Chairperson for Exec and whole school meetings, etc and",
-            "url": "https://drive.google.com/open?id=1OyympKBcjFtQPNibjC9O3ZkLj48ssmCu"
-          },
-          {
             "label": "Assembly Duty for Faculties",
             "url": "https://drive.google.com/drive/folders/1VHvruX9gI9sm77UA-ZFFGA4hkfxvlLdQ?usp=sharing"
           },
@@ -132,10 +120,6 @@
         "links": [
           {
             "label": "Playground",
-            "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvQkdEZDFWa3JrWkE"
-          },
-          {
-            "label": "Playground duty and roll classes",
             "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvQkdEZDFWa3JrWkE"
           },
           {
@@ -231,11 +215,7 @@
             "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvX1VrX1VSa21HR2c"
           },
           {
-            "label": "HSC data analysis",
-            "url": "https://drive.google.com/open?id=1G1olT0Od_8413p0Z92ZI4DW4-b1F63BXz1UPZfcVQbY"
-          },
-          {
-            "label": "blank HSC data analysis sheet",
+            "label": "HSC data analysis (includes blank template)",
             "url": "https://drive.google.com/open?id=1G1olT0Od_8413p0Z92ZI4DW4-b1F63BXz1UPZfcVQbY"
           },
           {
@@ -251,11 +231,7 @@
         "description": "Programs and registrations are to be completed for each current class and accessed via the faculty Google Drive. A program builder from NESA can be found here. A PowerPoint on how to use program builder can be found here. Links to current programs and monitoring folders can be found here. Some experimentation using Google Sites is occurring to access course information. Examples of this can be found here.",
         "links": [
           {
-            "label": "Programs and registrations",
-            "url": "https://drive.google.com/drive/u/1/folders/0B40F5Y8uF0rvTTR6SGpKYzdEWU0"
-          },
-          {
-            "label": "Google Drive",
+            "label": "Programs and registrations Google Drive",
             "url": "https://drive.google.com/drive/u/1/folders/0B40F5Y8uF0rvTTR6SGpKYzdEWU0"
           },
           {
@@ -311,11 +287,7 @@
         "description": "Assessment Schedule booklets for Yr10, Yr11 and Yr12 can be found on the WWHS Staff Shared Google Drive here. Past TAS assessment schedules can be found here. Assessment tasks need to be given out on the due date. A blank copy of stage 5 and 6 assessment task proforma can be found here. Changes to task dates should go via the executive and amendments made to the schedule and monitoring folders.",
         "links": [
           {
-            "label": "WWHS Staff",
-            "url": "https://drive.google.com/drive/folders/1s1dZTbWdtRPkDb4Id7Y21v0a2fjm-amm?usp=sharing"
-          },
-          {
-            "label": "Assessment Schedule booklets for Yr10, Yr11 and Yr12 can be found on the WWHS Staff Shared Google Drive",
+            "label": "WWHS Staff shared drive (assessment booklets)",
             "url": "https://drive.google.com/drive/folders/1s1dZTbWdtRPkDb4Id7Y21v0a2fjm-amm?usp=sharing"
           },
           {
@@ -376,15 +348,11 @@
         "code": "B9",
         "title": "Student Fees and safety shoes",
         "status": "updated 2022",
-        "description": "Students are to be given a note regarding subject fees and safety shoes within the first couple of lessons. Students have until week 6 to pay fees otherwise alternate material/work may need to be utilised. A list of subject fees can be found in each of the stage subject selection handbooks which can be found here. Students with incorrect footwear will need to be given alternate work. Copying the Workshop rules and the contract is a good option for this and it can be found here. Special rules must be followed when using knives in the kitchen. Faculty policy for using knives can be found here.",
+        "description": "Students are to be given a note regarding subject fees and safety shoes within the first couple of lessons. Students have until week 6 to pay fees otherwise alternate material/work may need to be utilised. A list of subject fees is available in the Subject Selection Handbooks / Videos section. Students with incorrect footwear will need to be given alternate work. Copying the Workshop rules and the contract is a good option for this and it can be found here. Special rules must be followed when using knives in the kitchen. Faculty policy for using knives can be found here.",
         "links": [
           {
             "label": "note",
             "url": "https://drive.google.com/file/d/1x02GzD5i7-dxux-w1wBYQCRvHtpbd5tl/view?usp=sharing"
-          },
-          {
-            "label": "list of subject fees can be found in each of the stage subject selection handbooks which",
-            "url": "https://drive.google.com/drive/folders/1hksqunt95IMI2r5D0zX2gsH0ls342w_x?usp=sharing"
           },
           {
             "label": "Copying the Workshop rules and the contract is a good option for this and it",
@@ -552,10 +520,6 @@
           {
             "label": "Power Grammar",
             "url": "https://drive.google.com/drive/folders/15TiLPJAxXZIKgm93roWISZrKTm7CusDx?usp=sharing"
-          },
-          {
-            "label": "technique used to break down passages of work called ‘Power Grammar’",
-            "url": "https://drive.google.com/drive/folders/15TiLPJAxXZIKgm93roWISZrKTm7CusDx?usp=sharing"
           }
         ]
       },
@@ -563,7 +527,7 @@
         "code": "B17",
         "title": "Senior monitoring folders",
         "status": "Updated 2022",
-        "description": "Teachers of senior classes are required to keep monitoring folders of each subject. Content for these folders can be found here. Hard copies of current classes are to be kept in the staff room. Electronic copies/backups can be kept here. Information from the department regarding Higher School Certificate Monitoring can be found at: https://education.nsw.gov.au/assessment-and-reporting/assessment/stage6 . Forms relating to the ‘signing off of HSC’ monitoring by the principal can be found here. VET monitoring information can be found here. NESA Monitoring Advice to principals can be found here. NESA Links to current programs and monitoring folders can be found here",
+        "description": "Teachers of senior classes are required to keep monitoring folders of each subject. Content for these folders can be found here. Hard copies of current classes are to be kept in the staff room. Electronic copies/backups can be kept here. Information from the department regarding Higher School Certificate Monitoring can be found at: https://education.nsw.gov.au/assessment-and-reporting/assessment/stage6 . Forms relating to the ‘signing off of HSC’ monitoring by the principal can be found here. VET monitoring information can be found here. NESA Monitoring Advice to principals can be found here. Use the Programs and Registration section for the latest NESA links to current programs and monitoring folders.",
         "links": [
           {
             "label": "Content for these folders",
@@ -584,10 +548,6 @@
           {
             "label": "NESA Monitoring Advice to principals",
             "url": "https://drive.google.com/drive/folders/1muI_7HwRG9Gadk6uPhWRP0A-No-wsm-J?usp=sharing"
-          },
-          {
-            "label": "NESA Links to current programs and monitoring folders",
-            "url": "https://drive.google.com/drive/folders/1nj9qyLUhQ7Ko6M2PECJ53Od6eJt_ktiq?usp=sharing"
           }
         ]
       },
@@ -806,11 +766,7 @@
         "description": "TAS / VET Budgets are divided up into 3 Cost Centres: TAS, Industrial Arts, and Home Economics. Further Internal order sections are broken up within each Cost Centre. The Faculty Budget spreadsheet can be found for here. Approval of orders are completed by the HT via a green purchase order form. Claims can be applied by using the orange claim form. Both forms can be obtained from the finance office. Budget allocations can be found at T:\\Office\\Finance\nInformation on how to order stationary via WINC can be found here.",
         "links": [
           {
-            "label": "3 Cost Centres",
-            "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvMGQ3NXFROFJnLWM"
-          },
-          {
-            "label": "Internal order sections",
+            "label": "Cost centres and internal order sections",
             "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvMGQ3NXFROFJnLWM"
           },
           {
@@ -831,12 +787,8 @@
         "code": "C2",
         "title": "Student Welfare and Behaviour",
         "status": "updated 2022",
-        "description": "Student Wellbeing and behaviour policy can be found  on the WWHS Staff google drive, here. Student welfare profiles are available on Sentral\nMonitoring of students with 3 or more Sentral entries in a 2 week period. Theses students should be excluded from all extra curricular activities. The list can be found here.",
+        "description": "Student Wellbeing and behaviour policy details are provided via the Whole School → Student Wellbeing section. Student welfare profiles are available on Sentral. Monitoring of students with 3 or more Sentral entries in a 2 week period should be excluded from all extra curricular activities. The list can be found here.",
         "links": [
-          {
-            "label": "Student Wellbeing and behaviour policy can be found  on the WWHS Staff google drive",
-            "url": "https://drive.google.com/drive/folders/1zy6i08CnsDwDOiXMhfm_EkS6Dl43Hpuh?usp=sharing"
-          },
           {
             "label": "Sentral",
             "url": "http://web1.waggawagga-h.schools.nsw.edu.au/wellbeing/"
@@ -854,16 +806,12 @@
         "description": "All staff must complete a PDP document each year and have it approved by their direct supervisor. Teachers Professional Development should relate directly to the Australian teaching standards which can be found here. Ongoing and completed PDP forms should be stored here. Evidence of meeting goals within a teachers PDP can be stored here. New online applications for rolesPDP’s can be found on SENTRAL. The departments PDP guideline document can be found here. Professional learning feedback forms can be found here. A code to Wagga High Schools Google Classroom is thly0x. A PDP guide developed by the HT Teaching and Learning can be found here. A collaboration notebook (One Note) for teaching communities can be found here.  Instructions for applying for professional learning can be found here.\n2023 Rotation for PDP days and sport duty can be found here.",
         "links": [
           {
-            "label": "document",
+            "label": "PDP templates and storage",
             "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvb0JjS0lDalZRQTg"
           },
           {
             "label": "Teachers Professional Development should relate directly to the Australian teaching standards which",
             "url": "https://drive.google.com/open?id=1JLgRXIP3R49gqfBZ1GrWyjIlcDTjsGo9"
-          },
-          {
-            "label": "Ongoing and completed PDP forms should be stored",
-            "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvb0JjS0lDalZRQTg"
           },
           {
             "label": "Evidence of meeting goals within a teachers PDP can be stored",
@@ -1038,11 +986,7 @@
         "description": "All chemicals need to be kept in a locked chemical cupboard and each item must be registered in “Chem Watch”, outlining the product name, amount, and where it is stored. A copy of the latest TAS chemicals files can be found here.  Also material safety data sheets are to be obtainable for each item. These are printed and stored in the TAS staff room above the headteacher VET’s desk. The department’s Chemical safety in schools  website can be found. A link to Chemwatch Gold can be found here. The Departments Chemical Safety Requirements can be found\nSafety Data sheets must be readily accessible in the room where the substances are used/stored. Access can be electronic. In the past SafeWork have recommended that the mini Safety Data sheets (one page) is kept in the room where they are stored, rather than the full version.  This is so that in the event of a power fail, easy access the summary SDS for emergency responses i.e. first aid, spills etc. Staff can then access the full one online if needed. Below is the link to Chemical safety requirements within the department, including CSIS. There is also a webinar that specifically deals with high school settings.\nhttps://education.nsw.gov.au/inside-the-department/health-and-safety/risk-management/chemicals-and-sharps   Cheryl McKee Work Health and Safety Advisor | Health and Safety Directorate 27.7.2021\nSafe Work Australia Preparation of safety data sheets for hazardous chemicals Code of Practice JUNE 2023\nDepartment of Ed - Health and Safety Directorates:-   FACT SHEETS\nChemicals:-\nHow to Approach Chemical Safety\nRequired Chemical Systems and Registers\nEveryday Chemicals & Cleaners\nGeneral Assistants and Farm Assistants\nGeneral Guidelines on How to Approach Chemical Safety - TAS\nChemical support material:-\nChemical Safety in Schools\nChemical Safety - GHS\nChecklist for working with hazardous substances - V1\nSharp objects support materials:-\nSharp objects - overview and key steps -V1\nGuidance in completing the risk management plan proforma - sharp objects - V2\nSample risk management plan: sharp objects - V1\nSafeWork - Hazardous chemicals\nChemical Safety in Schools (CSIS) Webinar slides\nNesa information\nSection 1: General information for all staff  here\n1.7 Risk Assessment - a pre-requisite for risk control\n1.8 Control measures for schools\n1.9 Hazardous Chemical Register and Manifest\n1.10 Managing chemicals in the school environment\n1.11 Protection equipment - Preventing chemical injury\n1.12 The Principal's guide to implementation\nSection 2: ChemWatch Technology Support  here\nChemWatch Training , Inventory files for the chemical register in Appendices B and Globally Harmonized System of Classification and labelling of Chemicals\nSection 3: Curriculum support Documents 3.3 (TAS)\nOrganising Chemicals  labelling, signs, storage\nSafe practice for technology learning environment  Lesson planning, preparation and maintenance of learning environment, Classroom management strategies, Contingency planning, Emergency evacuation procedures,\nUsing chemicals – containers, Preparation of chemicals, heating chemicals, fumes, spills and cleaning up\nSafe practices in food preparation areas, Using electric power tools\nInformation about common dangerous or hazardous activities General advise for chemicals commonly used in TAS ~\nadhesives,\ncleaning chemicals\nFabric dyes and printing inks\nfixatives\nmetals\n3.3.1 potential long-term health effects from some metal or their compounds\npaints\npetroleum products\nCommon dangerous or hazardous activities\nDisposal of unwanted materials",
         "links": [
           {
-            "label": "Chem Watch",
-            "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvb25JWkQtUmxXNDQ"
-          },
-          {
-            "label": "copy of the latest TAS chemicals files",
+            "label": "ChemWatch TAS chemical register",
             "url": "https://drive.google.com/open?id=0B40F5Y8uF0rvb25JWkQtUmxXNDQ"
           },
           {
@@ -1054,15 +998,11 @@
             "url": "https://online.det.nsw.edu.au/ecmjsp/chemicals/chemicals.cfm#skipToContent"
           },
           {
-            "label": "Chemwatch Gold",
+            "label": "Chemwatch Gold login",
             "url": "https://jr.chemwatch.net/chemwatch.web/account/login?ReturnUrl=%2fchemwatch.web%2fhome"
           },
           {
-            "label": "link to Chemwatch Gold",
-            "url": "https://jr.chemwatch.net/chemwatch.web/account/login?ReturnUrl=%2fchemwatch.web%2fhome"
-          },
-          {
-            "label": "https://education.nsw.gov.au/inside-the-department/health-and-safety/risk-management/chemicals-and-sharps",
+            "label": "Chemical safety requirements overview",
             "url": "https://education.nsw.gov.au/inside-the-department/health-and-safety/risk-management/chemicals-and-sharps"
           },
           {
@@ -1122,10 +1062,6 @@
             "url": "https://drive.google.com/drive/folders/1mQz9lpdd3rD8wgOWkbcXnITevqjddoue"
           },
           {
-            "label": "Section 1: General information for all staff",
-            "url": "https://education.nsw.gov.au/inside-the-department/facilities-assets-and-equipment/school-infrastructure-nsw/knowledge/directorates/operations/technical-services/compliance-and-environment/chemical-safety-in-schools/section-1--general-information-for-all-staff"
-          },
-          {
             "label": "1.7 Risk Assessment - a pre-requisite for risk control",
             "url": "https://education.nsw.gov.au/inside-the-department/facilities-assets-and-equipment/school-infrastructure-nsw/knowledge/directorates/operations/technical-services/compliance-and-environment/chemical-safety-in-schools/section-1--general-information-for-all-staff/1-7-risk-assessment---a-pre-requisite-for-risk-control"
           },
@@ -1154,10 +1090,6 @@
             "url": "https://education.nsw.gov.au/inside-the-department/facilities-assets-and-equipment/school-infrastructure-nsw/knowledge/directorates/operations/technical-services/compliance-and-environment/chemical-safety-in-schools/section-2--chemwatch-technology-support"
           },
           {
-            "label": "Section 2: ChemWatch Technology Support",
-            "url": "https://education.nsw.gov.au/inside-the-department/facilities-assets-and-equipment/school-infrastructure-nsw/knowledge/directorates/operations/technical-services/compliance-and-environment/chemical-safety-in-schools/section-2--chemwatch-technology-support"
-          },
-          {
             "label": "ChemWatch Training",
             "url": "https://chemwatch.training/"
           },
@@ -1171,10 +1103,6 @@
           },
           {
             "label": "Information about common dangerous or hazardous activities",
-            "url": "https://education.nsw.gov.au/inside-the-department/facilities-assets-and-equipment/school-infrastructure-nsw/knowledge/directorates/operations/technical-services/compliance-and-environment/chemical-safety-in-schools/section-3--curriculum-support-documents/3-3-4--information-about-common-dangerous-or-hazardous-activitie"
-          },
-          {
-            "label": "Common dangerous or hazardous activities",
             "url": "https://education.nsw.gov.au/inside-the-department/facilities-assets-and-equipment/school-infrastructure-nsw/knowledge/directorates/operations/technical-services/compliance-and-environment/chemical-safety-in-schools/section-3--curriculum-support-documents/3-3-4--information-about-common-dangerous-or-hazardous-activitie"
           },
           {


### PR DESCRIPTION
## Summary
- remove duplicate hyperlinks across TAS sections and update descriptions to reference the single authoritative location for shared resources
- clarify link labels for common documents such as the programs drive, assessment schedules, and PDP templates to make each entry self-descriptive
- clean up the chemical register listings so ChemWatch resources and departmental guidance appear once with clearer labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5e6ca92b483268c5be73a7e75e66d