### PR TITLE
Link resource headings directly to Google folders

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -372,7 +372,18 @@ function createResourceCard(category, section) {
 
   const header = document.createElement('header');
   const title = document.createElement('h3');
-  title.textContent = `${section.code}. ${section.title}`;
+  const headingText = `${section.code}. ${section.title}`;
+  if (section.links.length) {
+    const headingLink = document.createElement('a');
+    headingLink.href = section.links[0].url;
+    headingLink.target = '_blank';
+    headingLink.rel = 'noopener noreferrer';
+    headingLink.className = 'resource-heading-link';
+    headingLink.textContent = headingText;
+    title.append(headingLink);
+  } else {
+    title.textContent = headingText;
+  }
   header.append(title);
 
   if (section.status) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -556,6 +556,26 @@ body {
   font-size: 1.1rem;
 }
 
+.resource-card h3 a {
+  color: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.resource-card h3 a::after {
+  content: '↗';
+  font-size: 0.85rem;
+  opacity: 0.6;
+}
+
+.resource-card h3 a:hover,
+.resource-card h3 a:focus {
+  color: var(--accent-strong);
+  text-decoration: underline;
+}
+
 .status-tag {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- turn each resource card heading into a hyperlink that opens its first linked Google folder in a new tab
- add styles so linked headings retain the card appearance while signalling they are clickable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5f17ff93c83269a2b23d5bd3dc68d