### PR TITLE
Auto-open matching categories after searching

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -362,6 +362,9 @@ function shouldAutoOpenCategory(category) {
   if (state.showPinnedOnly) {
     return category.sections.some((section) => state.pinned.has(sectionKey(category.code, section.code)));
   }
+  if (state.searchTerm) {
+    return category.sections.length > 0 || category.categoryMatches;
+  }
   return false;
 }
 


### PR DESCRIPTION
## Summary
- automatically expand category accordions when a search term is active so filtered results are immediately visible

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d5f04ffc6083268ed7b4e6a804edd8