### PR TITLE
Add TAS folder index link to TAS tasks category

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -3,7 +3,12 @@
     "code": "A",
     "title": "TAS TASKS",
     "description": "Quick access to the VET section can be found here.",
-    "links": [],
+    "links": [
+      {
+        "label": "Browse TAS folders (A1–A12)",
+        "url": "https://drive.google.com/drive/u/0/folders/0B40F5Y8uF0rvfkl1S2FEbjRhVmJYRWYyY2dlOFVHMDdQeFNyQlRBUzBudmtHRGJKdE83VVk?resourcekey=0-fXD-BgXggkE5EyIeJJdt5g"
+      }
+    ],
     "sections": [
       {
         "code": "A1",


### PR DESCRIPTION
## Summary
- add a category-level link to the shared Google Drive folder that contains the TAS tasks subfolders (A1–A12)

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5f5c664488326ac54ffcc9e4d77ba