### PR TITLE
Add browse links to remaining categories

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -187,7 +187,13 @@
     "code": "B",
     "title": "Classroom",
     "description": "Everything you need to run classes day-to-day, from program documentation and assessment schedules to health plans, compliance records and student reporting workflows.",
-    "links": [],
+    "links": [
+      {
+        "label": "Browse classroom folders (B1–B30)",
+        "url": "#category-B",
+        "openInNewTab": false
+      }
+    ],
     "sections": [
       {
         "code": "B1",
@@ -762,7 +768,13 @@
     "code": "C",
     "title": "Faculty",
     "description": "Lead the TAS team with clarity—budget management, staff wellbeing processes, professional learning, accreditation and operational templates live here.",
-    "links": [],
+    "links": [
+      {
+        "label": "Browse faculty folders (C1–C32)",
+        "url": "#category-C",
+        "openInNewTab": false
+      }
+    ],
     "sections": [
       {
         "code": "C1",
@@ -1422,7 +1434,13 @@
     "code": "D",
     "title": "Whole School",
     "description": "Keep in step with whole-school expectations including mandatory reporting, emergency procedures, executive operations and shared reference handbooks.",
-    "links": [],
+    "links": [
+      {
+        "label": "Browse whole school folders (D1–D29)",
+        "url": "#category-D",
+        "openInNewTab": false
+      }
+    ],
     "sections": [
       {
         "code": "D1",

--- a/public/app.js
+++ b/public/app.js
@@ -229,9 +229,21 @@ function render() {
     linksContainer.innerHTML = '';
     category.links.forEach((link) => {
       const anchor = document.createElement('a');
+      const openInNewTab = link.openInNewTab !== false;
       anchor.href = link.url;
-      anchor.target = '_blank';
-      anchor.rel = 'noopener noreferrer';
+      if (openInNewTab) {
+        anchor.target = '_blank';
+        anchor.rel = 'noopener noreferrer';
+      } else {
+        anchor.target = '_self';
+      }
+      if (!openInNewTab && link.url.startsWith('#category-')) {
+        anchor.addEventListener('click', (event) => {
+          event.preventDefault();
+          const code = link.url.slice('#category-'.length).toUpperCase();
+          scrollToCategory(code);
+        });
+      }
       anchor.textContent = link.label;
       linksContainer.append(anchor);
     });


### PR DESCRIPTION
## Summary
- add quick browse buttons to the classroom, faculty, and whole school category cards so each section range is surfaced alongside TAS
- update the front-end link renderer to support in-page navigation for category quick links while keeping external resources opening in a new tab

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6118a74348326be7cd4fc2546f61c