### PR TITLE
Adjust QMS category link display

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -2320,9 +2320,14 @@
   },
   {
     "code": "G",
-    "title": "Trainer – Quality Management System (QMS) https://qmsveis.info/index.php",
+    "title": "Trainer – Quality Management System (QMS)",
     "description": "",
-    "links": [],
+    "links": [
+      {
+        "label": "QMS",
+        "url": "https://qmsveis.info/index.php"
+      }
+    ],
     "sections": [
       {
         "code": "G00",


### PR DESCRIPTION
## Summary
- update the QMS category to remove the raw URL from the title
- add a quick link so the QMS letters serve as the hyperlink

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d61bc7d1708326b6c0da123f28f696